### PR TITLE
Integrate Fuseki loader into admin

### DIFF
--- a/labs/backend/admin.py
+++ b/labs/backend/admin.py
@@ -28,6 +28,11 @@ class MyAdminSite(AdminSite):
             ),
             re_path(r"^load_fuseki/$", self.admin_view(views.load_fuseki), name="load_fuseki"),
             re_path(
+                r"^loader/(?P<action>load|unload|delete)/$",
+                self.admin_view(views.loader_manage_all),
+                name="loader_manage_all",
+            ),
+            re_path(
                 r"^backend/dashboard/$",
                 self.admin_view(views.dashboard),
                 name="dashboard",

--- a/labs/backend/templates/admin/data/dataset/change_list.html
+++ b/labs/backend/templates/admin/data/dataset/change_list.html
@@ -4,7 +4,7 @@
 {% block object-tools-items %}
   <li>
     <a href="{% url 'admin:load_from_github' %}" class="">
-     Import from Github
+     Import from judaicalink-site
     </a>
   </li>
   <li>
@@ -13,8 +13,18 @@
     </a>
   </li>
   <li>
-    <a href="{% url 'admin:load_fuseki' %}" class="">
+    <a href="{% url 'admin:loader_manage_all' 'load' %}" class="">
      Load in Fuseki
+    </a>
+  </li>
+  <li>
+    <a href="{% url 'admin:loader_manage_all' 'unload' %}" class="">
+     Unload from Fuseki
+    </a>
+  </li>
+  <li>
+    <a href="{% url 'admin:loader_manage_all' 'delete' %}" class="">
+     Delete in Fuseki
     </a>
   </li>
   {{ block.super }}

--- a/labs/backend/views.py
+++ b/labs/backend/views.py
@@ -36,10 +36,13 @@ def load_solr(request):
 
 
 def load_fuseki(request):
-    """
-    Fetches all data files and loads them in Fuseki.
-    """
-    tasks.call_command_as_task("load_all_datasets")
+    """Load all datasets in Fuseki using the loader script."""
+    tasks.call_command_as_task("fuseki_loader", "load")
+    return redirect(reverse("admin:data_dataset_changelist"))
+
+def loader_manage_all(request, action):
+    """Run the loader script with the given action for all datasets."""
+    tasks.call_command_as_task("fuseki_loader", action)
     return redirect(reverse("admin:data_dataset_changelist"))
 
 

--- a/labs/data/admin.py
+++ b/labs/data/admin.py
@@ -52,7 +52,34 @@ class DatasetAdmin(admin.ModelAdmin):
 
     formfield_overrides = formfield_overrides     
     inlines = [ DatafileAdmin, ]
-    actions = [ set_indexed, unset_indexed ]
+    actions = [ set_indexed, unset_indexed, 'load_fuseki', 'unload_fuseki', 'delete_fuseki' ]
+
+    def load_fuseki(self, request, queryset):
+        from backend import tasks
+        for ds in queryset:
+            slug = ds.dataslug or ds.name
+            tasks.call_command_as_task('fuseki_loader', 'load', slug)
+        self.message_user(request, 'Load started for selected datasets.')
+
+    load_fuseki.short_description = 'Load in Fuseki'
+
+    def unload_fuseki(self, request, queryset):
+        from backend import tasks
+        for ds in queryset:
+            slug = ds.dataslug or ds.name
+            tasks.call_command_as_task('fuseki_loader', 'unload', slug)
+        self.message_user(request, 'Unload started for selected datasets.')
+
+    unload_fuseki.short_description = 'Unload from Fuseki'
+
+    def delete_fuseki(self, request, queryset):
+        from backend import tasks
+        for ds in queryset:
+            slug = ds.dataslug or ds.name
+            tasks.call_command_as_task('fuseki_loader', 'delete', slug)
+        self.message_user(request, 'Delete started for selected datasets.')
+
+    delete_fuseki.short_description = 'Delete from Fuseki'
 
 
 

--- a/labs/data/management/commands/fuseki_loader.py
+++ b/labs/data/management/commands/fuseki_loader.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+import subprocess
+
+class Command(BaseCommand):
+    help = 'Wrapper around the judaicalink-loader script.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('action', choices=['load', 'unload', 'delete'])
+        parser.add_argument('dataset', nargs='?', default='all')
+
+    def handle(self, *args, **options):
+        cmd = ['judaicalink-loader', options['action']]
+        if options['dataset']:
+            cmd.append(options['dataset'])
+        subprocess.run(cmd, check=False)
+


### PR DESCRIPTION
## Summary
- wrap `judaicalink-loader` as management command `fuseki_loader`
- expose loader tasks in Dataset admin actions
- update dataset list buttons to run the loader and rename GitHub import button
- call loader from admin views
- add route for loader actions

## Testing
- `python labs/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840721d0f4083308b85ae0f0ced9eaa