### PR TITLE
Potential fix for code scanning alert no. 48: Resource exhaustion

### DIFF
--- a/labs/backend/static/backend/backend.js
+++ b/labs/backend/static/backend/backend.js
@@ -56,10 +56,13 @@
     }
     $('li#' + id).remove();
     var msgEl = $('<li id=' + id + ' class="' + level + '"><span class="message">' + message + '</span><span class="submessage">' + submessage + '</span></li>').appendTo('.messagelist');
-    if (timeout){
+    const MAX_TIMEOUT = 5000; // Maximum allowed timeout in milliseconds
+    if (timeout && timeout > 0 && timeout <= MAX_TIMEOUT) {
       window.setTimeout(function(){
         msgEl.remove();
       }, timeout);
+    } else if (timeout) {
+      console.warn('Invalid timeout value: ' + timeout);
     }
   }
 })(django.jQuery);


### PR DESCRIPTION
Potential fix for [https://github.com/judaicalink/judaicalink-labs/security/code-scanning/48](https://github.com/judaicalink/judaicalink-labs/security/code-scanning/48)

To fix the issue, we need to validate the `timeout` value before using it in the `setTimeout` call. Specifically, we should enforce a maximum allowable duration for the timer. If the `timeout` value exceeds this limit, we should either ignore it or handle it gracefully (e.g., log an error or use a default value). This ensures that attackers cannot exploit the application by providing excessively large `timeout` values.

The fix involves:
1. Adding a validation step for the `timeout` parameter in the `addMessage` function.
2. Setting a reasonable maximum limit for the `timeout` value (e.g., 5000 milliseconds).
3. Rejecting or defaulting invalid `timeout` values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
