### PR TITLE
Potential fix for code scanning alert no. 49: Information exposure through an exception

### DIFF
--- a/labs/api/solrapi.py
+++ b/labs/api/solrapi.py
@@ -90,7 +90,10 @@ def solr_proxy(request, core):
         cache.set(cache_key, solr_data, timeout=300)
         return Response(solr_data)
     except requests.RequestException as e:
-        return Response({'error': str(e)}, status=status.HTTP_502_BAD_GATEWAY)
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.error(f"Solr proxy error: {str(e)}")
+        return Response({'error': 'An internal error occurred. Please try again later.'}, status=status.HTTP_502_BAD_GATEWAY)
     # Add q.op to all views that use swagger_auto_schema
 
 q_op_param = openapi.Parameter(


### PR DESCRIPTION
Potential fix for [https://github.com/judaicalink/judaicalink-labs/security/code-scanning/49](https://github.com/judaicalink/judaicalink-labs/security/code-scanning/49)

To fix the issue, the code should be modified to return a generic error message to the user while logging the detailed exception message on the server. This ensures that sensitive information is not exposed to external users but remains accessible to developers for debugging purposes.

**Steps to implement the fix:**
1. Replace the `{'error': str(e)}` response with a generic error message, such as `{'error': 'An internal error occurred. Please try again later.'}`.
2. Log the detailed exception message (`str(e)`) using a logging library, such as Python's built-in `logging` module.
3. Ensure that the logging configuration is set up to capture and store logs appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
